### PR TITLE
Use alloc_system3ds again

### DIFF
--- a/ctr-std/Cargo.toml
+++ b/ctr-std/Cargo.toml
@@ -6,6 +6,10 @@ license = "MIT/Apache 2.0"
 [dependencies.compiler_builtins]
 git = "https://github.com/rust-lang-nursery/compiler-builtins"
 
+[dependencies.alloc_system]
+git = "https://github.com/FenrirWolf/alloc_system3ds/"
+branch = "new-allocator"
+
 [dependencies.libc]
 version = "0.2"
 default-features = false


### PR DESCRIPTION
Since we can't/shouldn't depend on the in-tree version

Also this is prolly ready to PR to the main repo too